### PR TITLE
layer.conf: update LAYERSERIES_COMPAT for mickledore

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,7 +17,7 @@ BBFILE_PATTERN_meta-shift = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-shift = "17"
 
 LAYERDEPENDS_meta-shift = "core openembedded-layer meta-python"
-LAYERSERIES_COMPAT_meta-shift = "kirkstone langdale"
+LAYERSERIES_COMPAT_meta-shift = "langdale mickledore"
 
 INHERIT += "shifttasks"
 


### PR DESCRIPTION
* oe-core switched to mickedore in: https://git.openembedded.org/openembedded-core/commit/?id=57239d66b933c4313cf331d35d13ec2d0661c38f

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>