### PR TITLE
cmake-native: refresh 0001-fix-clang-tidy-failure-by-target-option.pa…

### DIFF
--- a/recipes-devtools/cmake/files/0001-fix-clang-tidy-failure-by-target-option.patch
+++ b/recipes-devtools/cmake/files/0001-fix-clang-tidy-failure-by-target-option.patch
@@ -1,4 +1,4 @@
-From bf5b89c22e646f3a718af8dc00224b00a483b78d Mon Sep 17 00:00:00 2001
+From 1c02d40ce1b2adf59365e408aa2096ec90c84d8e Mon Sep 17 00:00:00 2001
 From: Sung Gon Kim <sunggon82.kim@lge.com>
 Date: Sun, 21 Feb 2021 12:15:32 +0000
 Subject: [PATCH] #269 Fixes an issue that clang-tidy causes compilation
@@ -8,13 +8,13 @@ Subject: [PATCH] #269 Fixes an issue that clang-tidy causes compilation
  1 file changed, 6 insertions(+)
 
 diff --git a/Source/cmcmd.cxx b/Source/cmcmd.cxx
-index de76d73..bc6ac1b 100644
+index 67394f90..11b363e7 100644
 --- a/Source/cmcmd.cxx
 +++ b/Source/cmcmd.cxx
-@@ -244,6 +244,12 @@ static int HandleTidy(const std::string& runCmd, const std::string& sourceFile,
-   tidy_cmd.emplace_back("--");
-   cm::append(tidy_cmd, orig_cmd);
-
+@@ -381,6 +381,12 @@ int HandleTidy(const std::string& runCmd, const std::string& sourceFile,
+     cm::append(tidy_cmd, orig_cmd);
+   }
+ 
 +  std::string target_sys;
 +  if (cmSystemTools::GetEnv("TARGET_SYS", target_sys)) {
 +    tidy_cmd.emplace_back("-target");
@@ -22,7 +22,5 @@ index de76d73..bc6ac1b 100644
 +  }
 +
    // Run the tidy command line.  Capture its stdout and hide its stderr.
+   int ret;
    std::string stdOut;
-   std::string stdErr;
---
-2.30.0


### PR DESCRIPTION
…tch to apply cleanly

* fixes: ERROR: cmake-native-3.25.1-r0 do_patch: Fuzz detected:

Applying patch 0001-fix-clang-tidy-failure-by-target-option.patch patching file Source/cmcmd.cxx
Hunk #1 succeeded at 381 with fuzz 2 (offset 137 lines).

The context lines in the patches can be updated with devtool:

    devtool modify cmake-native
    devtool finish --force-patch-refresh cmake-native <layer_path>

Don't forget to review changes done by devtool!

ERROR: cmake-native-3.25.1-r0 do_patch: QA Issue: Patch log indicates that patches do not apply cleanly. [patch-fuzz]

Signed-off-by: Martin Jansa <martin2.jansa@lgepartner.com>