### PR TITLE
perl: use GPL-1.0-or-later instead of obsolete GPL-1.0+

### DIFF
--- a/recipes-devtools/perl/libcanary-stability-perl_2013.bb
+++ b/recipes-devtools/perl/libcanary-stability-perl_2013.bb
@@ -4,7 +4,7 @@ It's not, at this stage, meant as a tool for other module authors, although in p
 
 HOMEPAGE = "https://metacpan.org/pod/Canary::Stability"
 SECTION = "libs"
-LICENSE = "Artistic-1.0 | GPL-1.0+"
+LICENSE = "Artistic-1.0 | GPL-1.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=043dba8b278e1db1b0ef93f30140b02b"
 
 DEPENDS += "perl"

--- a/recipes-devtools/perl/libcommon-sense-perl_3.75.bb
+++ b/recipes-devtools/perl/libcommon-sense-perl_3.75.bb
@@ -4,11 +4,11 @@ as defined by two typical (or not so typical - use your common sense) specimens 
 In fact, after working out details on which warnings and strict modes to enable and make fatal, \
 we found that we (and our code written so far, and others) fully agree on every option, \
 even though we never used warnings before, \
-so it seems this module indeed reflects a "common" sense among some long-time Perl coders."
+so it seems this module indeed reflects a 'common' sense among some long-time Perl coders."
 
 HOMEPAGE = "https://metacpan.org/pod/common::sense"
 SECTION = "libs"
-LICENSE = "Artistic-1.0 | GPL-1.0+"
+LICENSE = "Artistic-1.0 | GPL-1.0-or-later"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=043dba8b278e1db1b0ef93f30140b02b"
 
 DEPENDS += "perl"

--- a/recipes-devtools/perl/libjson-xs-perl_4.03.bb
+++ b/recipes-devtools/perl/libjson-xs-perl_4.03.bb
@@ -8,7 +8,7 @@ SECTION = "libs"
 LICENSE = "Artistic-1.0 | GPL-1.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=043dba8b278e1db1b0ef93f30140b02b"
 
-DEPENDS += "perl libcanary-stability-perl libcommon-sense-perl libtypes-serialiser-perl"
+DEPENDS += "perl libcanary-stability-perl libcommon-sense-perl libtypes-serialiser-perl libcanary-stability-perl-native"
 
 SRC_URI = "https://cpan.metacpan.org/authors/id/M/ML/MLEHMANN/JSON-XS-${PV}.tar.gz"
 

--- a/recipes-devtools/perl/libjson-xs-perl_4.03.bb
+++ b/recipes-devtools/perl/libjson-xs-perl_4.03.bb
@@ -5,7 +5,7 @@ To reach the latter goal it was written in C."
 
 HOMEPAGE = "https://metacpan.org/pod/JSON::XS"
 SECTION = "libs"
-LICENSE = "Artistic-1.0 | GPL-1.0+"
+LICENSE = "Artistic-1.0 | GPL-1.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=043dba8b278e1db1b0ef93f30140b02b"
 
 DEPENDS += "perl libcanary-stability-perl libcommon-sense-perl libtypes-serialiser-perl"

--- a/recipes-devtools/perl/libtypes-serialiser-perl_1.01.bb
+++ b/recipes-devtools/perl/libtypes-serialiser-perl_1.01.bb
@@ -5,7 +5,7 @@ so they become interoperable between each other."
 
 HOMEPAGE = "https://metacpan.org/pod/Types::Serialiser"
 SECTION = "libs"
-LICENSE = "Artistic-1.0 | GPL-1.0+"
+LICENSE = "Artistic-1.0 | GPL-1.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=043dba8b278e1db1b0ef93f30140b02b"
 
 DEPENDS += "perl libcommon-sense-perl"


### PR DESCRIPTION
* fixes: https://github.com/shift-left-test/meta-shift/issues/7

ERROR: libcanary-stability-perl-2013-r0 do_package_qa: QA Issue: Recipe LICENSE includes obsolete licenses GPL-1.0+ [obsolete-license]
ERROR: libtypes-serialiser-perl-1.01-r0 do_package_qa: QA Issue: Recipe LICENSE includes obsolete licenses GPL-1.0+ [obsolete-license]
ERROR: libcommon-sense-perl-3.75-r0 do_package_qa: QA Issue: Recipe LICENSE includes obsolete licenses GPL-1.0+ [obsolete-license]