### PR TITLE
cppcheck=v2.10.2 (fix build with gcc-13)

### DIFF
--- a/recipes-test/cppcheck/cppcheck/0001-cleaned-up-includes-based-on-include-what-you-use-45.patch
+++ b/recipes-test/cppcheck/cppcheck/0001-cleaned-up-includes-based-on-include-what-you-use-45.patch
@@ -7,8 +7,9 @@ Subject: [PATCH] cleaned up includes based on `include-what-you-use` (#4599)
 MJ: backported only the change for lib/mathlib.cpp which is necessary
     to fix build with gcc-13.
 
-Upstream-Status: Backport [https://github.com/danmar/cppcheck/commit/bd1ae69b00fa0be4df7ccea91604707e70129c6c]
 ---
+Upstream-Status: Backport [https://github.com/danmar/cppcheck/commit/bd1ae69b00fa0be4df7ccea91604707e70129c6c]
+
  lib/mathlib.cpp | 1 +
  1 file changed, 1 insertion(+)
 

--- a/recipes-test/cppcheck/cppcheck/0002-Add-missing-rebinding-trait-to-TaggedAllocator.patch
+++ b/recipes-test/cppcheck/cppcheck/0002-Add-missing-rebinding-trait-to-TaggedAllocator.patch
@@ -1,0 +1,33 @@
+From ba551054357c2d6059c4b0c86c17b6fbd723d09b Mon Sep 17 00:00:00 2001
+From: Christopher Wellons <wellons@nullprogram.com>
+Date: Wed, 26 Apr 2023 17:23:32 -0400
+Subject: [PATCH] Add missing rebinding trait to TaggedAllocator
+
+GCC 13 checks for this trait, and Cppcheck cannot be compiled without
+it. See: https://gcc.gnu.org/gcc-13/porting_to.html#alloc-rebind
+---
+Upstream-Status: Submitted [https://github.com/danmar/cppcheck/pull/5015]
+
+ lib/smallvector.h | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/lib/smallvector.h b/lib/smallvector.h
+index 42c45a173..a3c127a95 100644
+--- a/lib/smallvector.h
++++ b/lib/smallvector.h
+@@ -41,6 +41,15 @@ struct TaggedAllocator : std::allocator<T>
+     TaggedAllocator(Ts&&... ts)
+         : std::allocator<T>(std::forward<Ts>(ts)...)
+     {}
++
++    template<class U>
++    TaggedAllocator(const TaggedAllocator<U, N>);
++
++    template<class U>
++    struct rebind
++    {
++        using other = TaggedAllocator<U, N>;
++    };
+ };
+ 
+ template<typename T, std::size_t N = DefaultSmallVectorSize>

--- a/recipes-test/cppcheck/cppcheck_2.10.2.bb
+++ b/recipes-test/cppcheck/cppcheck_2.10.2.bb
@@ -9,6 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
 SRC_URI = "git://github.com/danmar/cppcheck.git;protocol=https;branch=2.10.x \
     file://0001-cleaned-up-includes-based-on-include-what-you-use-45.patch \
+    file://0002-Add-missing-rebinding-trait-to-TaggedAllocator.patch \
 "
 
 SRCREV = "5c2d64ec4809fcba712b1114cf0462962924b903"


### PR DESCRIPTION
* fixes https://github.com/shift-left-test/meta-shift/issues/10

* one more fix is needed to build with gcc-13 (I've tested it as part of https://github.com/shift-left-test/meta-shift/pull/11 but forgot to update it before it got merged).