### PR TITLE
*.patch: add Upstream-Status to all patches

### DIFF
--- a/recipes-devtools/cmake/files/0001-fix-clang-tidy-failure-by-target-option.patch
+++ b/recipes-devtools/cmake/files/0001-fix-clang-tidy-failure-by-target-option.patch
@@ -4,6 +4,8 @@ Date: Sun, 21 Feb 2021 12:15:32 +0000
 Subject: [PATCH] #269 Fixes an issue that clang-tidy causes compilation
 
 ---
+Upstream-Status: Pending
+
  Source/cmcmd.cxx | 6 ++++++
  1 file changed, 6 insertions(+)
 

--- a/recipes-devtools/cmake/files/0002-fix-cpplint-return-non-zero-exit-code.patch
+++ b/recipes-devtools/cmake/files/0002-fix-cpplint-return-non-zero-exit-code.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 diff --git a/Source/cmcmd.cxx b/Source/cmcmd.cxx
 index 500f4874..2435d4db 100644
 --- a/Source/cmcmd.cxx

--- a/recipes-test/cpplint/cpplint/0001-remove-pytest-runner-dependency.patch
+++ b/recipes-test/cpplint/cpplint/0001-remove-pytest-runner-dependency.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 diff --git a/setup.py b/setup.py
 index aef5c4e..01692bd 100755
 --- a/setup.py

--- a/recipes-test/duplo/duplo/0002-add-hpp-file-extension.patch
+++ b/recipes-test/duplo/duplo/0002-add-hpp-file-extension.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 diff --git a/src/FileTypeFactory.cpp b/src/FileTypeFactory.cpp
 index 2088562..759f5c4 100644
 --- a/src/FileTypeFactory.cpp

--- a/recipes-test/duplo/duplo/stdc++17_revert.patch
+++ b/recipes-test/duplo/duplo/stdc++17_revert.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index aeeea15..4f914e3 100644
 --- a/CMakeLists.txt

--- a/recipes-test/metrixpp/metrixpp/fix-to-ignore-errors-when-opening-file.patch
+++ b/recipes-test/metrixpp/metrixpp/fix-to-ignore-errors-when-opening-file.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 diff --git a/metrixpp/ext/std/tools/collect.py b/metrixpp/ext/std/tools/collect.py
 index 3c4bd9a..73ecfb5 100644
 --- a/metrixpp/ext/std/tools/collect.py

--- a/recipes-test/metrixpp/metrixpp/remove-python-requires.patch
+++ b/recipes-test/metrixpp/metrixpp/remove-python-requires.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 diff --git a/setup.py b/setup.py
 index 23f9c87..87a740d 100644
 --- a/setup.py

--- a/recipes-test/oelint-adv/oelint-adv/0001-change-output-option-to-make-json-format-report.patch
+++ b/recipes-test/oelint-adv/oelint-adv/0001-change-output-option-to-make-json-format-report.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 diff --git a/oelint_adv/__main__.py b/oelint_adv/__main__.py
 index a300984..d4c9b0a 100644
 --- a/oelint_adv/__main__.py

--- a/recipes-test/oelint-adv/oelint-adv/0002-add-logger.patch
+++ b/recipes-test/oelint-adv/oelint-adv/0002-add-logger.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 diff --git a/oelint_adv/__main__.py b/oelint_adv/__main__.py
 index d4c9b0a..b59460d 100644
 --- a/oelint_adv/__main__.py

--- a/recipes-test/oelint-adv/oelint-adv/0003-disable-SSL-CERTIFICATE_VERIFY_FAILED.patch
+++ b/recipes-test/oelint-adv/oelint-adv/0003-disable-SSL-CERTIFICATE_VERIFY_FAILED.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 diff --git a/oelint_adv/rule_base/rule_var_homepageping.py b/oelint_adv/rule_base/rule_var_homepageping.py
 index 79869b5..be50b14 100644
 --- a/oelint_adv/rule_base/rule_var_homepageping.py

--- a/recipes-test/oelint-adv/oelint-adv/0004-remove-requirements.txt.patch
+++ b/recipes-test/oelint-adv/oelint-adv/0004-remove-requirements.txt.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 diff --git a/requirements.txt b/requirements.txt
 index 4784c69..e69de29 100644
 --- a/requirements.txt

--- a/recipes-test/oelint-parser/oelint-parser/0001-do-not-add-inherited-files.patch
+++ b/recipes-test/oelint-parser/oelint-parser/0001-do-not-add-inherited-files.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 diff --git a/oelint_parser/parser.py b/oelint_parser/parser.py
 index a21d1e8..11252a7 100644
 --- a/oelint_parser/parser.py

--- a/recipes-test/oelint-parser/oelint-parser/0002-prevent-false-alarm-in-external-src-context.patch
+++ b/recipes-test/oelint-parser/oelint-parser/0002-prevent-false-alarm-in-external-src-context.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 diff --git a/oelint_parser/data/const-default.json b/oelint_parser/data/const-default.json
 index a67f8d5..d687c9a 100644
 --- a/oelint_parser/data/const-default.json

--- a/recipes-test/python/python3-bashlex/0001-compatability-for-low-versions-of-setuptools.patch
+++ b/recipes-test/python/python3-bashlex/0001-compatability-for-low-versions-of-setuptools.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 diff --git a/setup.py b/setup.py
 index 435fe1f..aa76a31 100644
 --- a/setup.py

--- a/recipes-test/python/python3-lcov-cobertura/0001-add-demangle-tool-option.patch
+++ b/recipes-test/python/python3-lcov-cobertura/0001-add-demangle-tool-option.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 diff --git a/lcov_cobertura/lcov_cobertura.py b/lcov_cobertura/lcov_cobertura.py
 index 379e405..f0a90d2 100755
 --- a/lcov_cobertura/lcov_cobertura.py

--- a/recipes-test/python/python3-lcov-cobertura/0002-add-condition-information.patch
+++ b/recipes-test/python/python3-lcov-cobertura/0002-add-condition-information.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 diff --git a/lcov_cobertura/lcov_cobertura.py b/lcov_cobertura/lcov_cobertura.py
 index b6564e3..280025e 100755
 --- a/lcov_cobertura/lcov_cobertura.py


### PR DESCRIPTION
There is new patch-status QA check in oe-core:
https://git.openembedded.org/openembedded-core/commit/?id=76a685bfcf927593eac67157762a53259089ea8a

This is temporary work around just to hide _many_ warnings from optional patch-status (if you add it to WARN_QA).

This just added
Upstream-Status: Pending
everywhere without actually investigating what's the proper status.

This is just to hide current QA warnings and to catch new .patch files being added without Upstream-Status, but the number of Pending patches is now terrible:

Patches in Pending state: 16 (89%)