### PR TITLE
cmake-native: use UNPACKDIR

### DIFF
--- a/recipes-devtools/cmake/cmake-native_%.bbappend
+++ b/recipes-devtools/cmake/cmake-native_%.bbappend
@@ -11,6 +11,6 @@ SRC_URI:append = " \
 
 do_install:append() {
     install -d ${D}${datadir}/cmake-${CMAKE_MAJOR_VERSION}/Modules
-    install -m 644 ${WORKDIR}/CMakeUtils.cmake ${D}${datadir}/cmake-${CMAKE_MAJOR_VERSION}/Modules/
-    install -m 644 ${WORKDIR}/FindGMock.cmake ${D}${datadir}/cmake-${CMAKE_MAJOR_VERSION}/Modules/
+    install -m 644 ${UNPACKDIR}/CMakeUtils.cmake ${D}${datadir}/cmake-${CMAKE_MAJOR_VERSION}/Modules/
+    install -m 644 ${UNPACKDIR}/FindGMock.cmake ${D}${datadir}/cmake-${CMAKE_MAJOR_VERSION}/Modules/
 }


### PR DESCRIPTION
* see: https://lists.openembedded.org/g/openembedded-architecture/message/2007

* fixes:
  | install: cannot stat 'work/x86_64-linux/cmake-native/3.28.3/CMakeUtils.cmake': No such file or directory
  | WARNING: exit code 1 from a shell command.