### PR TITLE
WIP: nativesdk-packagegroup-sdk-host: avoid dependency on nativesdk-l…

### DIFF
--- a/recipes-core/packagegroups/nativesdk-packagegroup-sdk-host.bbappend
+++ b/recipes-core/packagegroups/nativesdk-packagegroup-sdk-host.bbappend
@@ -3,7 +3,6 @@ RDEPENDS:${PN}:append = " \
     nativesdk-cppcheck \
     nativesdk-cpplint \
     nativesdk-gcovr \
-    nativesdk-lcov \
     nativesdk-python3-lcov-cobertura \
     nativesdk-qemu \
 "


### PR DESCRIPTION
…ibgfortran

* this is just FYI, hopefully the issue will be resolved in oe-core/master soon and this won't be needed

* until: https://lists.openembedded.org/g/openembedded-core/message/200915 is merged, the lcov dependency is causing:
```
NOTE: Resolving any missing task queue dependencies
ERROR: Nothing PROVIDES 'gcc-cross-x86_64' (but virtual:nativesdk:oe-core/meta/recipes-devtools/gcc/libgfortran_14.1.bb DEPENDS on or otherwise requires it). Close matches:
  clang-crosssdk-x86_64
  gcc-cross-aarch64
NOTE: Runtime target 'nativesdk-libgfortran-dev' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['nativesdk-libgfortran-dev', 'gcc-cross-x86_64']
NOTE: Runtime target 'nativesdk-gcov-symlinks' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['nativesdk-gcov-symlinks', 'nativesdk-libgfortran-dev', 'gcc-cross-x86_64']
NOTE: Runtime target 'nativesdk-lcov' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['nativesdk-lcov', 'nativesdk-gcov-symlinks', 'nativesdk-libgfortran-dev', 'gcc-cross-x86_64']
NOTE: Runtime target 'nativesdk-packagegroup-sdk-host' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['nativesdk-packagegroup-sdk-host', 'nativesdk-lcov', 'nativesdk-gcov-symlinks', 'nativesdk-libgfortran-dev', 'gcc-cross-x86_64']
NOTE: Runtime target 'image' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['image', 'nativesdk-packagegroup-sdk-host', 'nativesdk-lcov', 'nativesdk-gcov-symlinks', 'nativesdk-libgfortran-dev', 'gcc-cross-x86_64']
NOTE: Runtime target 'nativesdk-lcov-dev' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['nativesdk-lcov-dev', 'nativesdk-gcov-symlinks', 'nativesdk-libgfortran-dev', 'gcc-cross-x86_64']
NOTE: Runtime target 'nativesdk-gcc' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['nativesdk-gcc', 'nativesdk-libgfortran-dev', 'gcc-cross-x86_64']
NOTE: Runtime target 'nativesdk-cpp' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['nativesdk-cpp', 'nativesdk-libgfortran-dev', 'gcc-cross-x86_64']
ERROR: Nothing RPROVIDES 'nativesdk-libgfortran' (but virtual:nativesdk:oe-core/meta/recipes-devtools/gcc/libgfortran_14.1.bb RDEPENDS on or otherwise requires it)
No eligible RPROVIDERs exist for 'nativesdk-libgfortran'
NOTE: Runtime target 'nativesdk-libgfortran' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['nativesdk-libgfortran']
```
  as explained in:
  https://lists.openembedded.org/g/openembedded-core/topic/106704990#msg200913